### PR TITLE
fix: add missing h5 weight adjustment

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -105,6 +105,7 @@ body:is(.theme-dark, .theme-light) {
   --h2-weight: 500;
   --h3-weight: 500;
   --h4-weight: 500;
+  --h5-weight: 500;
   --h6-weight: 500;
 }
 


### PR DESCRIPTION
I'm not sure if this was deliberate or not, but I prefer to have my header weights the same